### PR TITLE
Customize for personio use case

### DIFF
--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -178,7 +178,6 @@ impl Param<metrics::EndpointLabels> for Http {
         metrics::InboundEndpointLabels {
             tls: self.tcp.tls.clone(),
             authority: None,
-            target_addr: self.tcp.addr.into(),
         }
         .into()
     }

--- a/linkerd/app/core/src/metrics/mod.rs
+++ b/linkerd/app/core/src/metrics/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     telemetry, tls,
     transport::{
         self,
-        labels::{TargetAddr, TlsAccept, TlsConnect},
+        labels::{TlsAccept, TlsConnect},
     },
 };
 use linkerd_addr::Addr;
@@ -16,7 +16,6 @@ use linkerd_metrics::FmtLabels;
 pub use linkerd_metrics::*;
 use std::{
     fmt::{self, Write},
-    net::SocketAddr,
     time::{Duration, SystemTime},
 };
 
@@ -66,7 +65,6 @@ pub enum EndpointLabels {
 pub struct InboundEndpointLabels {
     pub tls: tls::ConditionalServerTls,
     pub authority: Option<http::uri::Authority>,
-    pub target_addr: SocketAddr,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -74,7 +72,6 @@ pub struct OutboundEndpointLabels {
     pub server_id: tls::ConditionalClientTls,
     pub authority: Option<http::uri::Authority>,
     pub labels: Option<String>,
-    pub target_addr: SocketAddr,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -283,7 +280,7 @@ impl FmtLabels for InboundEndpointLabels {
             write!(f, ",")?;
         }
 
-        (TargetAddr(self.target_addr), TlsAccept::from(&self.tls)).fmt_labels(f)?;
+        (TlsAccept::from(&self.tls)).fmt_labels(f)?;
 
         Ok(())
     }
@@ -296,9 +293,8 @@ impl FmtLabels for OutboundEndpointLabels {
             write!(f, ",")?;
         }
 
-        let ta = TargetAddr(self.target_addr);
         let tls = TlsConnect::from(&self.server_id);
-        (ta, tls).fmt_labels(f)?;
+        tls.fmt_labels(f)?;
 
         if let Some(labels) = self.labels.as_ref() {
             write!(f, ",{}", labels)?;

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -303,7 +303,6 @@ impl Param<metrics::EndpointLabels> for Logical {
         metrics::InboundEndpointLabels {
             tls: self.tls.clone(),
             authority: Some(authority),
-            target_addr: self.addr.into(),
         }
         .into()
     }

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -299,9 +299,10 @@ impl Param<transport::labels::Key> for Logical {
 
 impl Param<metrics::EndpointLabels> for Logical {
     fn param(&self) -> metrics::EndpointLabels {
+        let authority = http::uri::Authority::from_static("personio.de");
         metrics::InboundEndpointLabels {
             tls: self.tls.clone(),
-            authority: self.logical.as_ref().map(|d| d.as_http_authority()),
+            authority: Some(authority),
             target_addr: self.addr.into(),
         }
         .into()

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -102,12 +102,9 @@ impl<P> svc::Param<transport::labels::Key> for Endpoint<P> {
 
 impl<P> svc::Param<metrics::OutboundEndpointLabels> for Endpoint<P> {
     fn param(&self) -> metrics::OutboundEndpointLabels {
-        let authority = self
-            .logical_addr
-            .as_ref()
-            .map(|LogicalAddr(a)| a.as_http_authority());
+        let authority = http::uri::Authority::from_static("personio.de");
         metrics::OutboundEndpointLabels {
-            authority,
+            authority: Some(authority),
             labels: metrics::prefix_labels("dst", self.metadata.labels().iter()),
             server_id: self.tls.clone(),
             target_addr: self.addr.into(),

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -107,7 +107,6 @@ impl<P> svc::Param<metrics::OutboundEndpointLabels> for Endpoint<P> {
             authority: Some(authority),
             labels: metrics::prefix_labels("dst", self.metadata.labels().iter()),
             server_id: self.tls.clone(),
-            target_addr: self.addr.into(),
         }
     }
 }

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -103,9 +103,14 @@ impl<P> svc::Param<transport::labels::Key> for Endpoint<P> {
 impl<P> svc::Param<metrics::OutboundEndpointLabels> for Endpoint<P> {
     fn param(&self) -> metrics::OutboundEndpointLabels {
         let authority = http::uri::Authority::from_static("personio.de");
+
+        let mut dst_labels = self.metadata.labels().clone();
+        dst_labels.remove("pod");
+        dst_labels.remove("pod_template_hash");
+
         metrics::OutboundEndpointLabels {
             authority: Some(authority),
-            labels: metrics::prefix_labels("dst", self.metadata.labels().iter()),
+            labels: metrics::prefix_labels("dst", dst_labels.iter()),
             server_id: self.tls.clone(),
         }
     }


### PR DESCRIPTION
This PR will do the following to reduce the cardinality of the linkerd-proxy metrics

- hardcode the "authority" label in metrics module to be "personio.de"
- remove the "target_addr" label in metrics module
- Remove the "dst_pod", "dst_pod_template_hash" label in metrics module