### PR TITLE
feat(metrics): remove dst_zone label, reduce number of latency buckets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUSTFLAGS: "-D warnings -A deprecated"
-  RUSTUP_MAX_RETRIES: 11
+  RUSTUP_MAX_RETRIES: 19
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -142,7 +142,7 @@ where
     let mut out = format!("{}_{}=\"{}\"", prefix, k0, v0);
 
     for (k, v) in labels_iter {
-        if k == "pod" || k == "pod_template_hash" {
+        if k == "pod" || k == "pod_template_hash" || k == "zone" {
             continue;
         }
 

--- a/linkerd/metrics/src/latency.rs
+++ b/linkerd/metrics/src/latency.rs
@@ -6,14 +6,7 @@ use super::histogram::{Bounds, Bucket, Histogram};
 /// milliseconds.
 pub const BOUNDS: &Bounds = &Bounds(&[
     Bucket::Le(1.0),
-    Bucket::Le(2.0),
-    Bucket::Le(3.0),
-    Bucket::Le(4.0),
-    Bucket::Le(5.0),
     Bucket::Le(10.0),
-    Bucket::Le(20.0),
-    Bucket::Le(30.0),
-    Bucket::Le(40.0),
     Bucket::Le(50.0),
     Bucket::Le(100.0),
     Bucket::Le(200.0),
@@ -21,15 +14,8 @@ pub const BOUNDS: &Bounds = &Bounds(&[
     Bucket::Le(400.0),
     Bucket::Le(500.0),
     Bucket::Le(1_000.0),
-    Bucket::Le(2_000.0),
-    Bucket::Le(3_000.0),
-    Bucket::Le(4_000.0),
     Bucket::Le(5_000.0),
     Bucket::Le(10_000.0),
-    Bucket::Le(20_000.0),
-    Bucket::Le(30_000.0),
-    Bucket::Le(40_000.0),
-    Bucket::Le(50_000.0),
     // A final upper bound.
     Bucket::Inf,
 ]);


### PR DESCRIPTION
The buckets of the metrics are reduced to:
1, 10, 50, 100, 200, 300, 400, 500, 1000, 5000, 10000

zone (availability zone) is totally removed