### PR TITLE
feat: remove metric labels with high cardinality

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUSTFLAGS: "-D warnings -A deprecated"
-  RUSTUP_MAX_RETRIES: 10
+  RUSTUP_MAX_RETRIES: 13
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.ref || github.head_ref }}
@@ -69,7 +69,7 @@ jobs:
           shopt -s extglob
           if [[ "$GITHUB_EVENT_NAME" == pull_request ]]; then
             echo version="0.0.0-test.${GITHUB_SHA:0:7}"
-            echo archs='["amd64"]'
+            echo archs='["amd64", "arm64"]'
             exit 0
           fi >> "$GITHUB_OUTPUT"
           if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+)?(\+[0-9A-Za-z-]+)?$ ]]; then

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -140,6 +140,23 @@ where
     Some(out)
 }
 
+pub fn prefix_outbound_endpoint_labels<'i, I>(prefix: &str, mut labels_iter: I) -> Option<String>
+where
+    I: Iterator<Item = (&'i String, &'i String)>,
+{
+    let (k0, v0) = labels_iter.next()?;
+    let mut out = format!("{}_{}=\"{}\"", prefix, k0, v0);
+
+    for (k, v) in labels_iter {
+        if k == "pod" || k == "pod_template_hash" || k == "zone" {
+            continue;
+        }
+
+        write!(out, ",{}_{}=\"{}\"", prefix, k, v).expect("label concat must succeed");
+    }
+    Some(out)
+}
+
 // === impl Metrics ===
 
 impl Metrics {
@@ -393,7 +410,7 @@ impl FmtLabels for Direction {
 
 impl<'a> FmtLabels for Authority<'a> {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "authority=\"{}\"", self.0)
+        write!(f, "authority=\"na\"")
     }
 }
 

--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -168,11 +168,10 @@ impl<'t> FmtLabels for TlsConnect<'t> {
 
 impl FmtLabels for TargetAddr {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Due to high cardinality of the target addresses and ips, we will only keep the port.
         write!(
             f,
-            "target_addr=\"{}\",target_ip=\"{}\",target_port=\"{}\"",
-            self.0,
-            self.0.ip(),
+            "target_addr=\"na\",target_ip=\"na\",target_port=\"{}\"",
             self.0.port()
         )
     }
@@ -208,7 +207,7 @@ mod tests {
         assert_eq!(
             labels.to_string(),
             "direction=\"inbound\",peer=\"src\",\
-            target_addr=\"192.0.2.4:40000\",target_ip=\"192.0.2.4\",target_port=\"40000\",\
+            target_addr=\"na\",target_ip=\"na\",target_port=\"40000\",\
             tls=\"true\",client_id=\"foo.id.example.com\",\
             srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testserver\""
         );

--- a/linkerd/app/integration/src/tests/discovery.rs
+++ b/linkerd/app/integration/src/tests/discovery.rs
@@ -454,14 +454,13 @@ mod http2 {
         // Simulate the first server falling over without discovery
         // knowing about it...
         tracing::info!(%alpha.addr, "Stopping");
-        let alpha_addr = alpha.addr;
         alpha.join().await;
 
         // Wait until the proxy has seen the `alpha` disconnect...
         metrics::metric("tcp_close_total")
             .label("peer", "dst")
             .label("direction", "outbound")
-            .label("target_addr", alpha_addr.to_string())
+            .label("target_addr", "na")
             .value(1u64)
             .assert_in(&metrics)
             .await;

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -56,10 +56,8 @@ impl Fixture {
 
         let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
         let tcp_dst_labels = metrics::labels().label("direction", "inbound");
-        let tcp_src_labels = tcp_dst_labels.clone().label("target_addr", orig_dst);
-        let labels = tcp_dst_labels
-            .clone()
-            .label("authority", "tele.test.svc.cluster.local");
+        let tcp_src_labels = tcp_dst_labels.clone().label("target_addr", "na");
+        let labels = tcp_dst_labels.clone().label("authority", "na");
         let tcp_src_labels = tcp_src_labels.label("peer", "src");
         let tcp_dst_labels = tcp_dst_labels.label("peer", "dst");
         Fixture {
@@ -98,7 +96,7 @@ impl Fixture {
         let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
         let tcp_labels = metrics::labels()
             .label("direction", "outbound")
-            .label("target_addr", orig_dst);
+            .label("target_addr", "na");
         let labels = tcp_labels.clone();
         let tcp_src_labels = tcp_labels.clone().label("peer", "src");
         let tcp_dst_labels = tcp_labels.label("peer", "dst");
@@ -153,7 +151,7 @@ impl TcpFixture {
         let src_labels = metrics::labels()
             .label("direction", "inbound")
             .label("peer", "src")
-            .label("target_addr", orig_dst)
+            .label("target_addr", "na")
             .label("srv_kind", "default")
             .label("srv_name", "all-unauthenticated");
 
@@ -194,7 +192,7 @@ impl TcpFixture {
             .label("peer", "src")
             .label("tls", "no_identity")
             .label("no_tls_reason", "loopback")
-            .label("target_addr", orig_dst);
+            .label("target_addr", "na");
         let dst_labels = metrics::labels()
             .label("direction", "outbound")
             .label("peer", "dst");
@@ -218,7 +216,7 @@ async fn admin_request_count() {
     let metrics = fixture.metrics;
     let metric = metrics::metric("request_total")
         .label("direction", "inbound")
-        .label("target_addr", metrics.target_addr())
+        .label("target_addr", "na")
         .value(1usize);
 
     // We can't assert that the metric is not present, since `GET /metrics`
@@ -233,7 +231,7 @@ async fn admin_transport_metrics() {
     let metrics = fixture.metrics;
     let labels = metrics::labels()
         .label("direction", "inbound")
-        .label("target_addr", metrics.target_addr())
+        .label("target_addr", "na")
         .label("peer", "src");
 
     let mut open_total = labels.metric("tcp_open_total").value(1usize);
@@ -553,7 +551,7 @@ mod outbound_dst_labels {
         let client = client::new(proxy.outbound, host);
         let tcp_labels = metrics::labels()
             .label("direction", "outbound")
-            .label("target_addr", addr);
+            .label("target_addr", "na");
         let labels = tcp_labels.clone();
         let f = Fixture {
             client,
@@ -695,140 +693,6 @@ mod outbound_dst_labels {
             "response_latency_ms_count",
         ] {
             labels.metric(metric).assert_in(&metrics).await;
-        }
-    }
-
-    // XXX(ver) This test is broken and/or irrelevant. linkerd/linkerd2#751.
-    #[tokio::test]
-    #[ignore]
-    async fn controller_updates_addr_labels() {
-        let _trace = trace_init();
-        info!("running test server");
-
-        let (
-            Fixture {
-                client,
-                metrics,
-                proxy: _proxy,
-                _profile,
-                dst_tx,
-                labels,
-                ..
-            },
-            addr,
-        ) = fixture("labeled.test.svc.cluster.local").await;
-        let dst_tx = dst_tx.unwrap();
-        dst_tx.send(
-            controller::destination_add(addr)
-                .addr_label("addr_label", "foo")
-                .set_label("set_label", "unchanged"),
-        );
-
-        let labels1 = labels
-            .clone()
-            .label("dst_addr_label", "foo")
-            .label("dst_set_label", "unchanged");
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-
-        // the first request should be labeled with `dst_addr_label="foo"`
-        for &metric in &[
-            "request_total",
-            "response_total",
-            "response_latency_ms_count",
-        ] {
-            labels1.metric(metric).value(1u64).assert_in(&metrics).await;
-        }
-
-        dst_tx.send(
-            controller::destination_add(addr)
-                .addr_label("addr_label", "bar")
-                .set_label("set_label", "unchanged"),
-        );
-
-        let labels2 = labels
-            .label("dst_addr_label", "bar")
-            .label("dst_set_label", "unchanged");
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-
-        // the second request should increment stats labeled with `dst_addr_label="bar"`
-        // the first request should be labeled with `dst_addr_label="foo"`
-        for &metric in &[
-            "request_total",
-            "response_total",
-            "response_latency_ms_count",
-        ] {
-            labels1.metric(metric).value(1u64).assert_in(&metrics).await;
-        }
-
-        // stats recorded from the first request should still be present.
-        // the first request should be labeled with `dst_addr_label="foo"`
-        for &metric in &[
-            "request_total",
-            "response_total",
-            "response_latency_ms_count",
-        ] {
-            labels2.metric(metric).value(1u64).assert_in(&metrics).await;
-        }
-    }
-
-    // XXX(ver) This test is broken and/or irrelevant. linkerd/linkerd2#751.
-    #[ignore]
-    #[tokio::test]
-    async fn controller_updates_set_labels() {
-        let _trace = trace_init();
-        info!("running test server");
-        let (
-            Fixture {
-                client,
-                metrics,
-                proxy: _proxy,
-                _profile,
-                dst_tx,
-                labels,
-                ..
-            },
-            addr,
-        ) = fixture("labeled.test.svc.cluster.local").await;
-        let dst_tx = dst_tx.unwrap();
-        dst_tx.send(controller::destination_add(addr).set_label("set_label", "foo"));
-
-        let labels1 = labels.clone().label("dst_set_label", "foo");
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        // the first request should be labeled with `dst_addr_label="foo"
-        for &metric in &[
-            "request_total",
-            "response_total",
-            "response_latency_ms_count",
-        ] {
-            labels1.metric(metric).value(1u64).assert_in(&client).await;
-        }
-
-        dst_tx.send(controller::destination_add(addr).set_label("set_label", "bar"));
-        let labels2 = labels.label("dst_set_label", "bar");
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        // the second request should increment stats labeled with `dst_addr_label="bar"`
-        for &metric in &[
-            "request_total",
-            "response_total",
-            "response_latency_ms_count",
-        ] {
-            labels2.metric(metric).value(1u64).assert_in(&metrics).await;
-        }
-        // stats recorded from the first request should still be present.
-        for &metric in &[
-            "request_total",
-            "response_total",
-            "response_latency_ms_count",
-        ] {
-            labels1.metric(metric).value(1u64).assert_in(&metrics).await;
         }
     }
 }

--- a/linkerd/app/integration/src/tests/telemetry/tcp_errors.rs
+++ b/linkerd/app/integration/src/tests/telemetry/tcp_errors.rs
@@ -103,8 +103,8 @@ impl Test {
     }
 }
 
-fn metric(proxy: &proxy::Listening) -> metrics::MetricMatch {
-    metrics::metric(METRIC).label("target_addr", proxy.inbound_server.as_ref().unwrap().addr)
+fn metric() -> metrics::MetricMatch {
+    metrics::metric(METRIC).label("target_addr", "na")
 }
 
 /// Tests that the detect metric is labeled and incremented on timeout.
@@ -120,7 +120,7 @@ async fn inbound_timeout() {
     tokio::time::sleep(TIMEOUT + Duration::from_millis(15)) // just in case
         .await;
 
-    metric(&proxy)
+    metric()
         .label("error", "tls detection timeout")
         .value(1u64)
         .assert_in(&metrics)
@@ -140,7 +140,7 @@ async fn inbound_io_err() {
     tcp_client.write(TcpFixture::HELLO_MSG).await;
     drop(tcp_client);
 
-    metric(&proxy)
+    metric()
         .label("error", "i/o")
         .value(1u64)
         .assert_in(&metrics)
@@ -169,9 +169,7 @@ async fn inbound_success() {
     );
     let no_tls_client = client::tcp(proxy.inbound);
 
-    let metric = metric(&proxy)
-        .label("error", "tls detection timeout")
-        .value(1u64);
+    let metric = metric().label("error", "tls detection timeout").value(1u64);
 
     // Connect with TLS. The metric should not be incremented.
     tls_client.get("/").await;
@@ -200,7 +198,7 @@ async fn inbound_multi() {
     let (proxy, metrics) = Test::default().run().await;
     let client = client::tcp(proxy.inbound);
 
-    let metric = metric(&proxy);
+    let metric = metric();
     let timeout_metric = metric.clone().label("error", "tls detection timeout");
     let io_metric = metric.label("error", "i/o");
 
@@ -246,7 +244,7 @@ async fn inbound_direct_multi() {
     let (proxy, metrics) = Test::new(proxy).run().await;
     let client = client::tcp(proxy.inbound);
 
-    let metric = metrics::metric(METRIC).label("target_addr", proxy.inbound);
+    let metric = metrics::metric(METRIC).label("target_addr", "na");
     let timeout_metric = metric.clone().label("error", "tls detection timeout");
     let no_tls_metric = metric.clone().label("error", "unexpected");
 
@@ -292,9 +290,9 @@ async fn inbound_invalid_ip() {
         .await;
 
     let client = client::tcp(proxy.inbound);
-    let metric = metric(&proxy)
+    let metric = metric()
         .label("error", "unexpected")
-        .label("target_addr", fake_ip);
+        .label("target_addr", "na");
 
     let tcp_client = client.connect().await;
     tcp_client.write(TcpFixture::HELLO_MSG).await;
@@ -357,7 +355,7 @@ async fn inbound_direct_success() {
     let no_tls_client = client::tcp(proxy1.inbound);
 
     let metric = metrics::metric(METRIC)
-        .label("target_addr", proxy1.inbound)
+        .label("target_addr", "na")
         .label("error", "tls detection timeout")
         .value(1u64);
 

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -5,7 +5,7 @@ use super::{balance::EwmaConfig, client, handle_proxy_error_headers};
 use crate::{http, stack_labels, BackendRef, Outbound, ParentRef};
 use linkerd_app_core::{
     config::{ConnectConfig, QueueConfig},
-    metrics::{prefix_labels, EndpointLabels, OutboundEndpointLabels},
+    metrics::{prefix_outbound_endpoint_labels, EndpointLabels, OutboundEndpointLabels},
     profiles,
     proxy::{
         api_resolve::{ConcreteAddr, Metadata, ProtocolHint},
@@ -211,7 +211,7 @@ where
     fn param(&self) -> OutboundEndpointLabels {
         OutboundEndpointLabels {
             authority: self.parent.param(),
-            labels: prefix_labels("dst", self.metadata.labels().iter()),
+            labels: prefix_outbound_endpoint_labels("dst", self.metadata.labels().iter()),
             server_id: self.param(),
             target_addr: self.addr.into(),
         }

--- a/linkerd/metrics/src/latency.rs
+++ b/linkerd/metrics/src/latency.rs
@@ -6,14 +6,7 @@ use super::histogram::{Bounds, Bucket, Histogram};
 /// milliseconds.
 pub const BOUNDS: &Bounds = &Bounds(&[
     Bucket::Le(1.0),
-    Bucket::Le(2.0),
-    Bucket::Le(3.0),
-    Bucket::Le(4.0),
-    Bucket::Le(5.0),
     Bucket::Le(10.0),
-    Bucket::Le(20.0),
-    Bucket::Le(30.0),
-    Bucket::Le(40.0),
     Bucket::Le(50.0),
     Bucket::Le(100.0),
     Bucket::Le(200.0),
@@ -21,15 +14,8 @@ pub const BOUNDS: &Bounds = &Bounds(&[
     Bucket::Le(400.0),
     Bucket::Le(500.0),
     Bucket::Le(1_000.0),
-    Bucket::Le(2_000.0),
-    Bucket::Le(3_000.0),
-    Bucket::Le(4_000.0),
     Bucket::Le(5_000.0),
     Bucket::Le(10_000.0),
-    Bucket::Le(20_000.0),
-    Bucket::Le(30_000.0),
-    Bucket::Le(40_000.0),
-    Bucket::Le(50_000.0),
     // A final upper bound.
     Bucket::Inf,
 ]);


### PR DESCRIPTION
This includes: target_addr, dst_pod, dst_pod_template_hash, authority

And it also reduces the number of latency buckets